### PR TITLE
refactor(frontend): 使用相对路径访问 API，适配反向代理部署

### DIFF
--- a/front-vue/.env.development
+++ b/front-vue/.env.development
@@ -1,2 +1,2 @@
-# API 基础 URL
-VITE_API_BASE_URL=http://localhost:42611/api
+# API 基础 URL（使用相对路径，适配远程部署）
+VITE_API_BASE_URL=/api

--- a/front-vue/src/api/index.js
+++ b/front-vue/src/api/index.js
@@ -3,7 +3,7 @@ import { useAuthStore } from '../stores/auth'
 
 // 创建 axios 实例
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:42611/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   timeout: 30000,
   withCredentials: true, // 支持跨域携带 cookies
   headers: {


### PR DESCRIPTION
- 将 VITE_API_BASE_URL 改为 /api（相对路径）
- 修改 axios 默认 baseURL 为 /api
- 通过 Nginx 反向代理时，前端和后端在同一域名下